### PR TITLE
[tc] Vpi Missing Scopes

### DIFF
--- a/include/verilated_vpi.cpp
+++ b/include/verilated_vpi.cpp
@@ -263,33 +263,24 @@ class VerilatedVpioScope VL_NOT_FINAL : public VerilatedVpio {
 protected:
     const VerilatedScope* const m_scopep;
     bool m_toplevel = false;
+    const char* m_name;
+    const char* m_fullname;
 
 public:
     explicit VerilatedVpioScope(const VerilatedScope* scopep)
         : m_scopep{scopep} {
-        std::string scopename = m_scopep->name();
-        std::string::size_type pos = std::string::npos;
-        // Look for '.' not inside escaped identifier
-        size_t i = 0;
-        while (i < scopename.length()) {
-            if (scopename[i] == '\\') {
-                while (i < scopename.length() && scopename[i] != ' ') ++i;
-                ++i;  // Proc ' ', it should always be there. Then grab '.' on next cycle
-            } else {
-                while (i < scopename.length() && scopename[i] != '.') ++i;
-                if (i < scopename.length()) pos = i++;
-            }
-        }
-        if (VL_UNLIKELY(pos == std::string::npos)) m_toplevel = true;
+        m_fullname = m_scopep->name();
+        if (std::strncmp(m_fullname, "TOP.", 4) == 0) m_fullname += 4;
+        m_name = m_scopep->identifier();
     }
     ~VerilatedVpioScope() override = default;
     static VerilatedVpioScope* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioScope*>(reinterpret_cast<VerilatedVpio*>(h));
     }
-    uint32_t type() const override { return vpiScope; }
+    uint32_t type() const override { return vpiGenScope; }
     const VerilatedScope* scopep() const { return m_scopep; }
-    const char* name() const override { return m_scopep->name(); }
-    const char* fullname() const override { return m_scopep->name(); }
+    const char* name() const override { return m_name; }
+    const char* fullname() const override { return m_fullname; }
     bool toplevel() const { return m_toplevel; }
 };
 
@@ -469,22 +460,29 @@ public:
 };
 
 class VerilatedVpioModule final : public VerilatedVpioScope {
-    const char* m_name;
-    const char* m_fullname;
 
 public:
     explicit VerilatedVpioModule(const VerilatedScope* modulep)
         : VerilatedVpioScope{modulep} {
-        m_fullname = m_scopep->name();
-        if (std::strncmp(m_fullname, "TOP.", 4) == 0) m_fullname += 4;
-        m_name = m_scopep->identifier();
+        // Look for '.' not inside escaped identifier
+        const std::string scopename = m_fullname;
+        std::string::size_type pos = std::string::npos;
+        size_t i = 0;
+        while (i < scopename.length()) {
+            if (scopename[i] == '\\') {
+                while (i < scopename.length() && scopename[i] != ' ') ++i;
+                ++i;  // Proc ' ', it should always be there. Then grab '.' on next cycle
+            } else {
+                while (i < scopename.length() && scopename[i] != '.') ++i;
+                if (i < scopename.length()) pos = i++;
+            }
+        }
+        if (VL_UNLIKELY(pos == std::string::npos)) m_toplevel = true;
     }
     static VerilatedVpioModule* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioModule*>(reinterpret_cast<VerilatedVpio*>(h));
     }
     uint32_t type() const override { return vpiModule; }
-    const char* name() const override { return m_name; }
-    const char* fullname() const override { return m_fullname; }
 };
 
 class VerilatedVpioModuleIter final : public VerilatedVpio {
@@ -507,8 +505,8 @@ public:
                 delete this;  // IEEE 37.2.2 vpi_scan at end does a vpi_release_handle
                 return nullptr;
             }
-            const VerilatedScope::Type itype = (*m_it)->type();
             const VerilatedScope* const modp = *m_it++;
+            const VerilatedScope::Type itype = modp->type();
             if (itype == VerilatedScope::SCOPE_MODULE) {
                 return (new VerilatedVpioModule{modp})->castVpiHandle();
             }
@@ -516,26 +514,54 @@ public:
     }
 };
 
+class VerilatedVpioScopeIter final : public VerilatedVpio {
+    const std::vector<const VerilatedScope*>* m_vec;
+    std::vector<const VerilatedScope*>::const_iterator m_it;
+
+public:
+    explicit VerilatedVpioScopeIter(const std::vector<const VerilatedScope*>& vec)
+        : m_vec{&vec} {
+        m_it = m_vec->begin();
+    }
+    ~VerilatedVpioScopeIter() override = default;
+    static VerilatedVpioScopeIter* castp(vpiHandle h) {
+        return dynamic_cast<VerilatedVpioScopeIter*>(reinterpret_cast<VerilatedVpio*>(h));
+    }
+    uint32_t type() const override { return vpiIterator; }
+    vpiHandle dovpi_scan() override {
+        while (true) {
+            if (m_it == m_vec->end()) {
+                delete this;  // IEEE 37.2.2 vpi_scan at end does a vpi_release_handle
+                return nullptr;
+            }
+            const VerilatedScope* const modp = *m_it++;
+            const VerilatedScope::Type itype = modp->type();
+            if (itype == VerilatedScope::SCOPE_OTHER) {
+                return (new VerilatedVpioScope{modp})->castVpiHandle();
+            } else if (itype == VerilatedScope::SCOPE_MODULE) {
+                return (new VerilatedVpioModule{modp})->castVpiHandle();
+            }
+        }
+    }
+};
+
+static const char* d_unit = "$unit";
 class VerilatedVpioPackage final : public VerilatedVpioScope {
-    std::string m_name;
-    std::string m_fullname;
+    std::string m_fullname_string;
 
 public:
     explicit VerilatedVpioPackage(const VerilatedScope* modulep)
         : VerilatedVpioScope{modulep} {
-        const char* sfullname = m_scopep->name();
-        if (std::strncmp(sfullname, "TOP.", 4) == 0) sfullname += 4;
-        m_fullname = std::string{sfullname} + "::";
-        if (m_fullname == "\\$unit ::") m_fullname = "$unit::";
-        m_name = std::string(m_scopep->identifier());
-        if (m_name == "\\$unit ") m_name = "$unit";
+        m_fullname_string = std::string{m_fullname} + "::";
+        if (m_fullname_string == "\\$unit ::") m_fullname_string = "$unit::";
+
+        if (strcmp(m_name, "\\$unit ") == 0) { m_name = d_unit; }
     }
     static VerilatedVpioPackage* castp(vpiHandle h) {
         return dynamic_cast<VerilatedVpioPackage*>(reinterpret_cast<VerilatedVpio*>(h));
     }
+    const char* fullname() const override { return m_fullname_string.c_str(); }
     uint32_t type() const override { return vpiPackage; }
-    const char* name() const override { return m_name.c_str(); }
-    const char* fullname() const override { return m_fullname.c_str(); }
 };
 
 class VerilatedVpioInstanceIter final : public VerilatedVpio {
@@ -1978,12 +2004,20 @@ vpiHandle vpi_iterate(PLI_INT32 type, vpiHandle object) {
         return ((new VerilatedVpioVarIter{vop, true})->castVpiHandle());
     }
     case vpiModule: {
-        const VerilatedVpioModule* const vop = VerilatedVpioModule::castp(object);
+        const VerilatedVpioScope* const vop = VerilatedVpioScope::castp(object);
         const VerilatedHierarchyMap* const map = VerilatedImp::hierarchyMap();
         const VerilatedScope* const modp = vop ? vop->scopep() : nullptr;
         const auto it = vlstd::as_const(map)->find(const_cast<VerilatedScope*>(modp));
         if (it == map->end()) return nullptr;
         return ((new VerilatedVpioModuleIter{it->second})->castVpiHandle());
+    }
+    case vpiInternalScope: {
+        const VerilatedVpioScope* const vop = VerilatedVpioScope::castp(object);
+        const VerilatedHierarchyMap* const map = VerilatedImp::hierarchyMap();
+        const VerilatedScope* const modp = vop ? vop->scopep() : nullptr;
+        const auto it = vlstd::as_const(map)->find(const_cast<VerilatedScope*>(modp));
+        if (it == map->end()) return nullptr;
+        return ((new VerilatedVpioScopeIter{it->second})->castVpiHandle());
     }
     case vpiInstance: {
         if (object) return nullptr;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -253,7 +253,6 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     void buildVpiHierarchy() {
         for (ScopeNames::const_iterator it = m_scopeNames.begin(); it != m_scopeNames.end();
              ++it) {
-            if (it->second.m_type != "SCOPE_MODULE") continue;
 
             const string symName = it->second.m_symName;
             string above = symName;

--- a/src/V3EmitCSyms.cpp
+++ b/src/V3EmitCSyms.cpp
@@ -185,6 +185,7 @@ class EmitCSyms final : EmitCBaseVisitorConst {
     }
 
     void varHierarchyScopes(string scp) {
+        string::size_type dotpos = scp.rfind('.');
         while (!scp.empty()) {
             const auto scpit = m_vpiScopeCandidates.find(scopeSymString(scp));
             if ((scpit != m_vpiScopeCandidates.end())
@@ -194,9 +195,10 @@ class EmitCSyms final : EmitCBaseVisitorConst {
                 if (!pair.second) pair.first->second.m_type = scpit->second.m_type;
             }
             string::size_type pos = scp.rfind("__DOT__");
-            if (pos == string::npos) {
-                pos = scp.rfind('.');
+            if (pos == string::npos || pos < dotpos) {
+                pos = dotpos;
                 if (pos == string::npos) break;
+                dotpos = scp.rfind('.', pos - 1);
             }
             scp.resize(pos);
         }

--- a/test_regress/t/t_time_vpi_c.cpp
+++ b/test_regress/t/t_time_vpi_c.cpp
@@ -74,7 +74,7 @@ void dpi_show(svScope obj) {
 void vpi_show(vpiHandle obj) {
     const char* namep;
     if (obj) {
-        namep = vpi_get_str(vpiName, obj);
+        namep = vpi_get_str(vpiFullName, obj);
     } else {
         namep = "global";
     }

--- a/test_regress/t/t_vpi_dump.cpp
+++ b/test_regress/t/t_vpi_dump.cpp
@@ -38,7 +38,7 @@ std::map<int32_t, std::vector<int32_t>> iterate_over = [] {
     };
 
     std::vector<int32_t> module_options = {
-        vpiModule,  // Aldec SEGV on mixed language
+        // vpiModule,  // Aldec SEGV on mixed language
         // vpiModuleArray,       // Aldec SEGV on mixed language
         // vpiIODecl,            // Don't care about these
         vpiMemory, vpiIntegerVar, vpiRealVar,

--- a/test_regress/t/t_vpi_dump.iv.out
+++ b/test_regress/t/t_vpi_dump.iv.out
@@ -53,6 +53,14 @@ t (vpiModule) t
             vpiReg:
             t.cond_scope.scoped_sub.subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
             t.cond_scope.scoped_sub.subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+        t.cond_scope.sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen
+            vpiInternalScope:
+            t.cond_scope.sub_wrap_gen.my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub
+                vpiNet:
+                t.cond_scope.sub_wrap_gen.my_sub.redundant (vpiNet) t.cond_scope.sub_wrap_gen.my_sub.redundant
+                vpiReg:
+                t.cond_scope.sub_wrap_gen.my_sub.subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1
+                t.cond_scope.sub_wrap_gen.my_sub.subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2
     t.intf_arr[0] (vpiModule) t.intf_arr[0]
     t.intf_arr[1] (vpiModule) t.intf_arr[1]
     t.outer_scope[1] (vpiGenScope) t.outer_scope[1]
@@ -226,5 +234,13 @@ t (vpiModule) t
         vpiReg:
         t.sub.subsig1 (vpiReg) t.sub.subsig1
         t.sub.subsig2 (vpiReg) t.sub.subsig2
+    t.sub_wrap (vpiModule) t.sub_wrap
+        vpiInternalScope:
+        t.sub_wrap.my_sub (vpiModule) t.sub_wrap.my_sub
+            vpiNet:
+            t.sub_wrap.my_sub.redundant (vpiNet) t.sub_wrap.my_sub.redundant
+            vpiReg:
+            t.sub_wrap.my_sub.subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1
+            t.sub_wrap.my_sub.subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2
 *-* All Finished *-*
-t/t_vpi_dump.v:75: $finish called at 0 (1s)
+t/t_vpi_dump.v:76: $finish called at 0 (1s)

--- a/test_regress/t/t_vpi_dump.iv.out
+++ b/test_regress/t/t_vpi_dump.iv.out
@@ -4,13 +4,6 @@ t (vpiModule) t
     t.clk (vpiNet) t.clk
     vpiReg:
     t.x (vpiReg) t.x
-    vpiModule:
-    t.sub (vpiModule) t.sub
-        vpiNet:
-        t.sub.redundant (vpiNet) t.sub.redundant
-        vpiReg:
-        t.sub.subsig1 (vpiReg) t.sub.subsig1
-        t.sub.subsig2 (vpiReg) t.sub.subsig2
     vpiParameter:
     t.do_generate (vpiParameter) t.do_generate
         vpiConstType=vpiBinaryConst
@@ -22,16 +15,6 @@ t (vpiModule) t
     a (vpiPort) (null)
     vpiInternalScope:
     t.arr[1] (vpiGenScope) t.arr[1]
-        vpiModule:
-        t.arr[1].arr (vpiModule) t.arr[1].arr
-            vpiReg:
-            t.arr[1].arr.check (vpiReg) t.arr[1].arr.check
-            t.arr[1].arr.rfr (vpiReg) t.arr[1].arr.rfr
-            t.arr[1].arr.sig (vpiReg) t.arr[1].arr.sig
-            t.arr[1].arr.verbose (vpiReg) t.arr[1].arr.verbose
-            vpiParameter:
-            t.arr[1].arr.LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-                vpiConstType=vpiBinaryConst
         vpiParameter:
         t.arr[1].i (vpiParameter) t.arr[1].i
             vpiConstType=vpiBinaryConst
@@ -46,16 +29,6 @@ t (vpiModule) t
             t.arr[1].arr.LENGTH (vpiParameter) t.arr[1].arr.LENGTH
                 vpiConstType=vpiBinaryConst
     t.arr[2] (vpiGenScope) t.arr[2]
-        vpiModule:
-        t.arr[2].arr (vpiModule) t.arr[2].arr
-            vpiReg:
-            t.arr[2].arr.check (vpiReg) t.arr[2].arr.check
-            t.arr[2].arr.rfr (vpiReg) t.arr[2].arr.rfr
-            t.arr[2].arr.sig (vpiReg) t.arr[2].arr.sig
-            t.arr[2].arr.verbose (vpiReg) t.arr[2].arr.verbose
-            vpiParameter:
-            t.arr[2].arr.LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-                vpiConstType=vpiBinaryConst
         vpiParameter:
         t.arr[2].i (vpiParameter) t.arr[2].i
             vpiConstType=vpiBinaryConst
@@ -70,13 +43,6 @@ t (vpiModule) t
             t.arr[2].arr.LENGTH (vpiParameter) t.arr[2].arr.LENGTH
                 vpiConstType=vpiBinaryConst
     t.cond_scope (vpiGenScope) t.cond_scope
-        vpiModule:
-        t.cond_scope.scoped_sub (vpiModule) t.cond_scope.scoped_sub
-            vpiNet:
-            t.cond_scope.scoped_sub.redundant (vpiNet) t.cond_scope.scoped_sub.redundant
-            vpiReg:
-            t.cond_scope.scoped_sub.subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
-            t.cond_scope.scoped_sub.subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
         vpiParameter:
         t.cond_scope.scoped_wire (vpiParameter) t.cond_scope.scoped_wire
             vpiConstType=vpiBinaryConst
@@ -87,6 +53,8 @@ t (vpiModule) t
             vpiReg:
             t.cond_scope.scoped_sub.subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
             t.cond_scope.scoped_sub.subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+    t.intf_arr[0] (vpiModule) t.intf_arr[0]
+    t.intf_arr[1] (vpiModule) t.intf_arr[1]
     t.outer_scope[1] (vpiGenScope) t.outer_scope[1]
         vpiParameter:
         t.outer_scope[1].i (vpiParameter) t.outer_scope[1].i
@@ -95,16 +63,6 @@ t (vpiModule) t
             vpiConstType=vpiBinaryConst
         vpiInternalScope:
         t.outer_scope[1].inner_scope[1] (vpiGenScope) t.outer_scope[1].inner_scope[1]
-            vpiModule:
-            t.outer_scope[1].inner_scope[1].arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
-                vpiReg:
-                t.outer_scope[1].inner_scope[1].arr.check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
-                t.outer_scope[1].inner_scope[1].arr.rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
-                t.outer_scope[1].inner_scope[1].arr.sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
-                t.outer_scope[1].inner_scope[1].arr.verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
-                vpiParameter:
-                t.outer_scope[1].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[1].inner_scope[1].j (vpiParameter) t.outer_scope[1].inner_scope[1].j
                 vpiConstType=vpiBinaryConst
@@ -121,16 +79,6 @@ t (vpiModule) t
                 t.outer_scope[1].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[1].inner_scope[2] (vpiGenScope) t.outer_scope[1].inner_scope[2]
-            vpiModule:
-            t.outer_scope[1].inner_scope[2].arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
-                vpiReg:
-                t.outer_scope[1].inner_scope[2].arr.check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
-                t.outer_scope[1].inner_scope[2].arr.rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
-                t.outer_scope[1].inner_scope[2].arr.sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
-                t.outer_scope[1].inner_scope[2].arr.verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
-                vpiParameter:
-                t.outer_scope[1].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[1].inner_scope[2].j (vpiParameter) t.outer_scope[1].inner_scope[2].j
                 vpiConstType=vpiBinaryConst
@@ -147,16 +95,6 @@ t (vpiModule) t
                 t.outer_scope[1].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[1].inner_scope[3] (vpiGenScope) t.outer_scope[1].inner_scope[3]
-            vpiModule:
-            t.outer_scope[1].inner_scope[3].arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
-                vpiReg:
-                t.outer_scope[1].inner_scope[3].arr.check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
-                t.outer_scope[1].inner_scope[3].arr.rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
-                t.outer_scope[1].inner_scope[3].arr.sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
-                t.outer_scope[1].inner_scope[3].arr.verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
-                vpiParameter:
-                t.outer_scope[1].inner_scope[3].arr.LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[1].inner_scope[3].j (vpiParameter) t.outer_scope[1].inner_scope[3].j
                 vpiConstType=vpiBinaryConst
@@ -180,16 +118,6 @@ t (vpiModule) t
             vpiConstType=vpiBinaryConst
         vpiInternalScope:
         t.outer_scope[2].inner_scope[1] (vpiGenScope) t.outer_scope[2].inner_scope[1]
-            vpiModule:
-            t.outer_scope[2].inner_scope[1].arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
-                vpiReg:
-                t.outer_scope[2].inner_scope[1].arr.check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
-                t.outer_scope[2].inner_scope[1].arr.rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
-                t.outer_scope[2].inner_scope[1].arr.sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
-                t.outer_scope[2].inner_scope[1].arr.verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
-                vpiParameter:
-                t.outer_scope[2].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[2].inner_scope[1].j (vpiParameter) t.outer_scope[2].inner_scope[1].j
                 vpiConstType=vpiBinaryConst
@@ -206,16 +134,6 @@ t (vpiModule) t
                 t.outer_scope[2].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[2].inner_scope[2] (vpiGenScope) t.outer_scope[2].inner_scope[2]
-            vpiModule:
-            t.outer_scope[2].inner_scope[2].arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
-                vpiReg:
-                t.outer_scope[2].inner_scope[2].arr.check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
-                t.outer_scope[2].inner_scope[2].arr.rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
-                t.outer_scope[2].inner_scope[2].arr.sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
-                t.outer_scope[2].inner_scope[2].arr.verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
-                vpiParameter:
-                t.outer_scope[2].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[2].inner_scope[2].j (vpiParameter) t.outer_scope[2].inner_scope[2].j
                 vpiConstType=vpiBinaryConst
@@ -232,16 +150,6 @@ t (vpiModule) t
                 t.outer_scope[2].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[2].inner_scope[3] (vpiGenScope) t.outer_scope[2].inner_scope[3]
-            vpiModule:
-            t.outer_scope[2].inner_scope[3].arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
-                vpiReg:
-                t.outer_scope[2].inner_scope[3].arr.check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
-                t.outer_scope[2].inner_scope[3].arr.rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
-                t.outer_scope[2].inner_scope[3].arr.sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
-                t.outer_scope[2].inner_scope[3].arr.verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
-                vpiParameter:
-                t.outer_scope[2].inner_scope[3].arr.LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[2].inner_scope[3].j (vpiParameter) t.outer_scope[2].inner_scope[3].j
                 vpiConstType=vpiBinaryConst
@@ -265,16 +173,6 @@ t (vpiModule) t
             vpiConstType=vpiBinaryConst
         vpiInternalScope:
         t.outer_scope[3].inner_scope[1] (vpiGenScope) t.outer_scope[3].inner_scope[1]
-            vpiModule:
-            t.outer_scope[3].inner_scope[1].arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
-                vpiReg:
-                t.outer_scope[3].inner_scope[1].arr.check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
-                t.outer_scope[3].inner_scope[1].arr.rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
-                t.outer_scope[3].inner_scope[1].arr.sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
-                t.outer_scope[3].inner_scope[1].arr.verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
-                vpiParameter:
-                t.outer_scope[3].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[3].inner_scope[1].j (vpiParameter) t.outer_scope[3].inner_scope[1].j
                 vpiConstType=vpiBinaryConst
@@ -291,16 +189,6 @@ t (vpiModule) t
                 t.outer_scope[3].inner_scope[1].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[3].inner_scope[2] (vpiGenScope) t.outer_scope[3].inner_scope[2]
-            vpiModule:
-            t.outer_scope[3].inner_scope[2].arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
-                vpiReg:
-                t.outer_scope[3].inner_scope[2].arr.check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
-                t.outer_scope[3].inner_scope[2].arr.rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
-                t.outer_scope[3].inner_scope[2].arr.sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
-                t.outer_scope[3].inner_scope[2].arr.verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
-                vpiParameter:
-                t.outer_scope[3].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[3].inner_scope[2].j (vpiParameter) t.outer_scope[3].inner_scope[2].j
                 vpiConstType=vpiBinaryConst
@@ -317,16 +205,6 @@ t (vpiModule) t
                 t.outer_scope[3].inner_scope[2].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
                     vpiConstType=vpiBinaryConst
         t.outer_scope[3].inner_scope[3] (vpiGenScope) t.outer_scope[3].inner_scope[3]
-            vpiModule:
-            t.outer_scope[3].inner_scope[3].arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
-                vpiReg:
-                t.outer_scope[3].inner_scope[3].arr.check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
-                t.outer_scope[3].inner_scope[3].arr.rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
-                t.outer_scope[3].inner_scope[3].arr.sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
-                t.outer_scope[3].inner_scope[3].arr.verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
-                vpiParameter:
-                t.outer_scope[3].inner_scope[3].arr.LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-                    vpiConstType=vpiBinaryConst
             vpiParameter:
             t.outer_scope[3].inner_scope[3].j (vpiParameter) t.outer_scope[3].inner_scope[3].j
                 vpiConstType=vpiBinaryConst
@@ -349,4 +227,4 @@ t (vpiModule) t
         t.sub.subsig1 (vpiReg) t.sub.subsig1
         t.sub.subsig2 (vpiReg) t.sub.subsig2
 *-* All Finished *-*
-t/t_vpi_dump.v:65: $finish called at 0 (1s)
+t/t_vpi_dump.v:75: $finish called at 0 (1s)

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -29,141 +29,261 @@ t (vpiModule) t
     text_word (vpiReg) t.text_word
     twoone (vpiReg) t.twoone
     x (vpiReg) TOP.x
-    vpiModule:
-    arr (vpiModule) t.arr[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.arr[1].arr.check
-        rfr (vpiReg) t.arr[1].arr.rfr
-        sig (vpiReg) t.arr[1].arr.sig
-        verbose (vpiReg) t.arr[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.arr[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.arr[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.arr[2].arr.check
-        rfr (vpiReg) t.arr[2].arr.rfr
-        sig (vpiReg) t.arr[2].arr.sig
-        verbose (vpiReg) t.arr[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.arr[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    scoped_sub (vpiModule) t.cond_scope.scoped_sub
-        vpiReg:
-        subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
-        subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
-        vpiParameter:
-    arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
-        rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
-        sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
-        verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
-        rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
-        sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
-        verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
-        rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
-        sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
-        verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
-        rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
-        sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
-        verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
-        rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
-        sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
-        verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
-        rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
-        sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
-        verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
-        rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
-        sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
-        verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
-        rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
-        sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
-        verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
-            vpiConstType=vpiDecConst
-    arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
-        vpiReg:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-        check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
-        rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
-        sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
-        verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
-        vpiParameter:
-        LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
-            vpiConstType=vpiDecConst
-    sub (vpiModule) t.sub
-        vpiReg:
-        subsig1 (vpiReg) t.sub.subsig1
-        subsig2 (vpiReg) t.sub.subsig2
-        vpiParameter:
     vpiParameter:
     do_generate (vpiParameter) t.do_generate
         vpiConstType=vpiDecConst
     long_int (vpiParameter) t.long_int
         vpiConstType=vpiDecConst
+    vpiInternalScope:
+    arr[1] (vpiGenScope) t.arr[1]
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        arr (vpiModule) t.arr[1].arr
+            vpiReg:
+            LENGTH (vpiParameter) t.arr[1].arr.LENGTH
+                vpiConstType=vpiDecConst
+            check (vpiReg) t.arr[1].arr.check
+            rfr (vpiReg) t.arr[1].arr.rfr
+            sig (vpiReg) t.arr[1].arr.sig
+            verbose (vpiReg) t.arr[1].arr.verbose
+            vpiParameter:
+            LENGTH (vpiParameter) t.arr[1].arr.LENGTH
+                vpiConstType=vpiDecConst
+    arr[2] (vpiGenScope) t.arr[2]
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        arr (vpiModule) t.arr[2].arr
+            vpiReg:
+            LENGTH (vpiParameter) t.arr[2].arr.LENGTH
+                vpiConstType=vpiDecConst
+            check (vpiReg) t.arr[2].arr.check
+            rfr (vpiReg) t.arr[2].arr.rfr
+            sig (vpiReg) t.arr[2].arr.sig
+            verbose (vpiReg) t.arr[2].arr.verbose
+            vpiParameter:
+            LENGTH (vpiParameter) t.arr[2].arr.LENGTH
+                vpiConstType=vpiDecConst
+    cond_scope (vpiGenScope) t.cond_scope
+        vpiReg:
+        scoped_wire (vpiParameter) t.cond_scope.scoped_wire
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_wire (vpiParameter) t.cond_scope.scoped_wire
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        scoped_sub (vpiModule) t.cond_scope.scoped_sub
+            vpiReg:
+            subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
+            subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
+            vpiParameter:
+    intf_arr[0] (vpiModule) t.intf_arr[0]
+        vpiReg:
+        addr (vpiReg) t.intf_arr[0].addr
+        vpiParameter:
+    intf_arr[1] (vpiModule) t.intf_arr[1]
+        vpiReg:
+        addr (vpiReg) t.intf_arr[1].addr
+        vpiParameter:
+    outer_scope[1] (vpiGenScope) t.outer_scope[1]
+        vpiReg:
+        scoped_param (vpiParameter) t.outer_scope[1].scoped_param
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_param (vpiParameter) t.outer_scope[1].scoped_param
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        inner_scope[1] (vpiGenScope) t.outer_scope[1].inner_scope[1]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[1].inner_scope[1].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[1].arr.check
+                rfr (vpiReg) t.outer_scope[1].inner_scope[1].arr.rfr
+                sig (vpiReg) t.outer_scope[1].inner_scope[1].arr.sig
+                verbose (vpiReg) t.outer_scope[1].inner_scope[1].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[1].inner_scope[2]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[1].inner_scope[2].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[2].arr.check
+                rfr (vpiReg) t.outer_scope[1].inner_scope[2].arr.rfr
+                sig (vpiReg) t.outer_scope[1].inner_scope[2].arr.sig
+                verbose (vpiReg) t.outer_scope[1].inner_scope[2].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[1].inner_scope[3]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[1].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[1].inner_scope[3].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[1].inner_scope[3].arr.check
+                rfr (vpiReg) t.outer_scope[1].inner_scope[3].arr.rfr
+                sig (vpiReg) t.outer_scope[1].inner_scope[3].arr.sig
+                verbose (vpiReg) t.outer_scope[1].inner_scope[3].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[1].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+    outer_scope[2] (vpiGenScope) t.outer_scope[2]
+        vpiReg:
+        scoped_param (vpiParameter) t.outer_scope[2].scoped_param
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_param (vpiParameter) t.outer_scope[2].scoped_param
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        inner_scope[1] (vpiGenScope) t.outer_scope[2].inner_scope[1]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[2].inner_scope[1].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[1].arr.check
+                rfr (vpiReg) t.outer_scope[2].inner_scope[1].arr.rfr
+                sig (vpiReg) t.outer_scope[2].inner_scope[1].arr.sig
+                verbose (vpiReg) t.outer_scope[2].inner_scope[1].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[2].inner_scope[2]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[2].inner_scope[2].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[2].arr.check
+                rfr (vpiReg) t.outer_scope[2].inner_scope[2].arr.rfr
+                sig (vpiReg) t.outer_scope[2].inner_scope[2].arr.sig
+                verbose (vpiReg) t.outer_scope[2].inner_scope[2].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[2].inner_scope[3]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[2].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[2].inner_scope[3].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[2].inner_scope[3].arr.check
+                rfr (vpiReg) t.outer_scope[2].inner_scope[3].arr.rfr
+                sig (vpiReg) t.outer_scope[2].inner_scope[3].arr.sig
+                verbose (vpiReg) t.outer_scope[2].inner_scope[3].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[2].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+    outer_scope[3] (vpiGenScope) t.outer_scope[3]
+        vpiReg:
+        scoped_param (vpiParameter) t.outer_scope[3].scoped_param
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        scoped_param (vpiParameter) t.outer_scope[3].scoped_param
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        inner_scope[1] (vpiGenScope) t.outer_scope[3].inner_scope[1]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[1].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[3].inner_scope[1].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[1].arr.check
+                rfr (vpiReg) t.outer_scope[3].inner_scope[1].arr.rfr
+                sig (vpiReg) t.outer_scope[3].inner_scope[1].arr.sig
+                verbose (vpiReg) t.outer_scope[3].inner_scope[1].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[1].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[2] (vpiGenScope) t.outer_scope[3].inner_scope[2]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[2].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[3].inner_scope[2].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[2].arr.check
+                rfr (vpiReg) t.outer_scope[3].inner_scope[2].arr.rfr
+                sig (vpiReg) t.outer_scope[3].inner_scope[2].arr.sig
+                verbose (vpiReg) t.outer_scope[3].inner_scope[2].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[2].arr.LENGTH
+                    vpiConstType=vpiDecConst
+        inner_scope[3] (vpiGenScope) t.outer_scope[3].inner_scope[3]
+            vpiReg:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiParameter:
+            scoped_param_inner (vpiParameter) t.outer_scope[3].inner_scope[3].scoped_param_inner
+                vpiConstType=vpiDecConst
+            vpiInternalScope:
+            arr (vpiModule) t.outer_scope[3].inner_scope[3].arr
+                vpiReg:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+                check (vpiReg) t.outer_scope[3].inner_scope[3].arr.check
+                rfr (vpiReg) t.outer_scope[3].inner_scope[3].arr.rfr
+                sig (vpiReg) t.outer_scope[3].inner_scope[3].arr.sig
+                verbose (vpiReg) t.outer_scope[3].inner_scope[3].arr.verbose
+                vpiParameter:
+                LENGTH (vpiParameter) t.outer_scope[3].inner_scope[3].arr.LENGTH
+                    vpiConstType=vpiDecConst
+    sub (vpiModule) t.sub
+        vpiReg:
+        subsig1 (vpiReg) t.sub.subsig1
+        subsig2 (vpiReg) t.sub.subsig2
+        vpiParameter:
 *-* All Finished *-*

--- a/test_regress/t/t_vpi_dump.out
+++ b/test_regress/t/t_vpi_dump.out
@@ -78,6 +78,15 @@ t (vpiModule) t
             subsig1 (vpiReg) t.cond_scope.scoped_sub.subsig1
             subsig2 (vpiReg) t.cond_scope.scoped_sub.subsig2
             vpiParameter:
+        sub_wrap_gen (vpiModule) t.cond_scope.sub_wrap_gen
+            vpiReg:
+            vpiParameter:
+            vpiInternalScope:
+            my_sub (vpiModule) t.cond_scope.sub_wrap_gen.my_sub
+                vpiReg:
+                subsig1 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig1
+                subsig2 (vpiReg) t.cond_scope.sub_wrap_gen.my_sub.subsig2
+                vpiParameter:
     intf_arr[0] (vpiModule) t.intf_arr[0]
         vpiReg:
         addr (vpiReg) t.intf_arr[0].addr
@@ -286,4 +295,13 @@ t (vpiModule) t
         subsig1 (vpiReg) t.sub.subsig1
         subsig2 (vpiReg) t.sub.subsig2
         vpiParameter:
+    sub_wrap (vpiModule) t.sub_wrap
+        vpiReg:
+        vpiParameter:
+        vpiInternalScope:
+        my_sub (vpiModule) t.sub_wrap.my_sub
+            vpiReg:
+            subsig1 (vpiReg) t.sub_wrap.my_sub.subsig1
+            subsig2 (vpiReg) t.sub_wrap.my_sub.subsig2
+            vpiParameter:
 *-* All Finished *-*

--- a/test_regress/t/t_vpi_dump.v
+++ b/test_regress/t/t_vpi_dump.v
@@ -13,6 +13,14 @@ typedef struct packed {
    int              sel;  // select
 } t_bus;
 
+interface TestInterface();
+
+   logic [31:0] addr;
+   modport source (input addr);
+
+endinterface
+
+
 module t (  /*AUTOARG*/
     // Outputs
     x,
@@ -57,6 +65,8 @@ module t (  /*AUTOARG*/
    t_bus bus1;
 
    sub sub ();
+
+   TestInterface intf_arr[2]();
 
 
    initial begin

--- a/test_regress/t/t_vpi_dump.v
+++ b/test_regress/t/t_vpi_dump.v
@@ -6,6 +6,7 @@
 // Version 2.0.
 // SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
 
+/* verilator public_on */
 
 typedef struct packed {
    logic [3:0][7:0] adr;  // address
@@ -95,15 +96,19 @@ module t (  /*AUTOARG*/
       end
    endgenerate
 
+   sub_wrapper sub_wrap ();
 
 
-   if (do_generate == 1) begin : cond_scope
-      sub scoped_sub ();
-      parameter int scoped_wire = 1;
-   end else begin : cond_scope_else
-      sub scoped_sub ();
-      parameter int scoped_wire = 2;
-   end
+   generate
+      if (do_generate == 1) begin : cond_scope
+         sub scoped_sub ();
+         parameter int scoped_wire = 1;
+
+         sub_wrapper sub_wrap_gen ();
+      end else begin : cond_scope_else
+         sub scoped_sub_else ();
+      end
+   endgenerate
 
 endmodule : t
 
@@ -138,3 +143,8 @@ module arr;
    end
 
 endmodule : arr
+
+
+module sub_wrapper;
+   sub my_sub ();
+endmodule

--- a/test_regress/t/t_vpi_dump_missing_scopes.cpp
+++ b/test_regress/t/t_vpi_dump_missing_scopes.cpp
@@ -1,0 +1,179 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//*************************************************************************
+//
+// Copyright 2010-2011 by Wilson Snyder. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+//
+//*************************************************************************
+
+#include "svdpi.h"
+#include "vpi_user.h"
+
+#include <cstdio>
+
+// These require the above. Comment prevents clang-format moving them
+#include "TestCheck.h"
+#include "TestSimulator.h"
+#include "TestVpi.h"
+
+#include <map>
+#include <vector>
+
+int errors = 0;
+
+// vpiType -> list of vpiTypes to iterate over
+std::map<int32_t, std::vector<int32_t>> iterate_over = [] {
+    // static decltype(iterate_over) iterate_over = [] {
+    /* for reused lists */
+
+    // vpiInstance is the base class for module, program, interface, etc.
+    std::vector<int32_t> instance_options = {
+        vpiNet,
+        vpiNetArray,
+        vpiReg,
+        vpiRegArray,
+    };
+
+    std::vector<int32_t> module_options = {
+        // vpiModule,  // Aldec SEGV on mixed language
+        // vpiModuleArray,       // Aldec SEGV on mixed language
+        // vpiIODecl,            // Don't care about these
+        vpiMemory, vpiIntegerVar, vpiRealVar,
+        // vpiRealNet, Vpi extension
+        vpiStructVar, vpiStructNet, vpiNamedEvent, vpiNamedEventArray, vpiParameter,
+        // vpiVariables, // parent of vpiReg, vpiRegArray, vpiIntegerVar, etc vars
+        // vpiSpecParam,         // Don't care
+        // vpiParamAssign,       // Aldec SEGV on mixed language
+        // vpiDefParam,          // Don't care
+        vpiPrimitive, vpiPrimitiveArray,
+        // vpiContAssign,        // Don't care
+        // vpiProcess,  // Don't care
+        vpiModPath, vpiTchk, vpiAttribute, vpiPort, vpiInternalScope,
+        // vpiInterface,         // Aldec SEGV on mixed language
+        // vpiInterfaceArray,    // Aldec SEGV on mixed language
+    };
+
+    // append base class vpiInstance members
+    module_options.insert(module_options.begin(), instance_options.begin(),
+                          instance_options.end());
+
+    std::vector<int32_t> struct_options = {
+        vpiNet,       vpiReg,       vpiRegArray,       vpiMemory,
+        vpiParameter, vpiPrimitive, vpiPrimitiveArray, vpiAttribute,
+        vpiMember,
+    };
+
+    return decltype(iterate_over){
+        {vpiModule, module_options},
+        {vpiInterface, instance_options},
+        {vpiGenScope, module_options},
+
+        {vpiStructVar, struct_options},
+        {vpiStructNet, struct_options},
+
+        {vpiNet,
+         {
+             // vpiContAssign,        // Driver and load handled separately
+             // vpiPrimTerm,
+             // vpiPathTerm,
+             // vpiTchkTerm,
+             // vpiDriver,
+             // vpiLocalDriver,
+             // vpiLoad,
+             // vpiLocalLoad,
+             vpiNetBit,
+         }},
+        {vpiNetArray,
+         {
+             vpiNet,
+         }},
+        {vpiRegArray,
+         {
+             vpiReg,
+         }},
+        {vpiMemory,
+         {
+             vpiMemoryWord,
+         }},
+        {vpiPort,
+         {
+             vpiPortBit,
+         }},
+        {vpiGate,
+         {
+             vpiPrimTerm,
+             vpiTableEntry,
+             vpiUdpDefn,
+         }},
+        {vpiPackage,
+         {
+             vpiParameter,
+         }},
+    };
+}();
+
+void modDump(TestVpiHandle& it, int n) {
+
+    if (n > 8) {
+        printf("going too deep\n");
+        return;
+    }
+
+    while (const TestVpiHandle& hndl = vpi_scan(it)) {
+        for (int i = 0; i < n; i++) printf("    ");
+        const int type = vpi_get(vpiType, hndl);
+        const char* name = vpi_get_str(vpiName, hndl);
+        const char* fullname = vpi_get_str(vpiFullName, hndl);
+        printf("%s (%s) %s\n", name, strFromVpiObjType(type), fullname);
+        if (type == vpiParameter || type == vpiConstType) {
+            for (int i = 0; i < n + 1; i++) printf("    ");
+            printf("vpiConstType=%s\n", strFromVpiConstType(vpi_get(vpiConstType, hndl)));
+        }
+
+        if (iterate_over.find(type) == iterate_over.end()) { continue; }
+        for (int type : iterate_over.at(type)) {
+            TestVpiHandle subIt = vpi_iterate(type, hndl);
+            if (subIt) {
+                for (int i = 0; i < n + 1; i++) printf("    ");
+                printf("%s:\n", strFromVpiObjType(type));
+                modDump(subIt, n + 1);
+            }
+        }
+    }
+    it.freed();
+}
+
+PLI_INT32 start_of_sim(t_cb_data* data) {
+    TestVpiHandle it = vpi_iterate(vpiModule, NULL);
+    TEST_CHECK_NZ(it);
+    modDump(it, 0);
+    return 0;
+}
+
+//cver, xcelium entry
+void vpi_compat_bootstrap(void) {
+
+    // We're able to call vpi_main() here on Verilator/Xcelium,
+    // but Icarus complains (rightfully so)
+    s_cb_data cb_data;
+    s_vpi_time vpi_time;
+
+    vpi_time.high = 0;
+    vpi_time.low = 0;
+    vpi_time.type = vpiSimTime;
+
+    cb_data.reason = cbStartOfSimulation;
+    cb_data.cb_rtn = &start_of_sim;
+    cb_data.obj = NULL;
+    cb_data.time = &vpi_time;
+    cb_data.value = NULL;
+    cb_data.index = 0;
+    cb_data.user_data = NULL;
+    TestVpiHandle callback_h = vpi_register_cb(&cb_data);
+}
+
+// Verilator (via t_vpi_main.cpp), and standard LRM entry
+void (*vlog_startup_routines[])() = {vpi_compat_bootstrap, 0};

--- a/test_regress/t/t_vpi_dump_missing_scopes.out
+++ b/test_regress/t/t_vpi_dump_missing_scopes.out
@@ -1,0 +1,36 @@
+t (vpiModule) t
+    vpiReg:
+    a (vpiReg) TOP.a
+    clk (vpiReg) TOP.clk
+    x (vpiReg) TOP.x
+    vpiParameter:
+    vpiInternalScope:
+    top_wrap_1 (vpiModule) t.top_wrap_1
+        vpiReg:
+        LENGTH (vpiParameter) t.top_wrap_1.LENGTH
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        LENGTH (vpiParameter) t.top_wrap_1.LENGTH
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        after_gen_loop (vpiModule) t.top_wrap_1.gen_loop[0].after_gen_loop
+            vpiReg:
+            subsig1 (vpiReg) t.top_wrap_1.gen_loop[0].after_gen_loop.subsig1
+            vpiParameter:
+    top_wrap_2 (vpiModule) t.top_wrap_2
+        vpiReg:
+        LENGTH (vpiParameter) t.top_wrap_2.LENGTH
+            vpiConstType=vpiDecConst
+        vpiParameter:
+        LENGTH (vpiParameter) t.top_wrap_2.LENGTH
+            vpiConstType=vpiDecConst
+        vpiInternalScope:
+        gen_loop[0] (vpiGenScope) t.top_wrap_2.gen_loop[0]
+            vpiReg:
+            vpiParameter:
+            vpiInternalScope:
+            after_gen_loop (vpiModule) t.top_wrap_2.gen_loop[0].after_gen_loop
+                vpiReg:
+                subsig1 (vpiReg) t.top_wrap_2.gen_loop[0].after_gen_loop.subsig1
+                vpiParameter:
+*-* All Finished *-*

--- a/test_regress/t/t_vpi_dump_missing_scopes.pl
+++ b/test_regress/t/t_vpi_dump_missing_scopes.pl
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2024 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+skip("Known compiler limitation")
+    if $Self->cxx_version =~ /\(GCC\) 4.4/;
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    make_pli => 1,
+    iv_flags2 => ["-g2005-sv"],
+    verilator_flags2 => ["--exe --vpi --public-flat-rw --no-l2name $Self->{t_dir}/t_vpi_dump.cpp $Self->{t_dir}/TestVpiMain.cpp"],
+    # name => "t_vpi_dump",
+    # v_flags2 => ["t/t_vpi_dump.cpp"],
+    make_flags => 'CPPFLAGS_ADD=-DVL_NO_LEGACY',
+    );
+
+execute(
+    use_libvpi => 1,
+    check_finished => 1,
+    expect_filename => $Self->{golden_filename},
+    xrun_run_expect_filename => ($Self->{golden_filename} =~ s/\.out$/.xrun.out/r),
+    iv_run_expect_filename => ($Self->{golden_filename} =~ s/\.out$/.iv.out/r),
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_vpi_dump_missing_scopes.v
+++ b/test_regress/t/t_vpi_dump_missing_scopes.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Copyright 2010 by Wilson Snyder. This program is free software; you can
+// redistribute it and/or modify it under the terms of either the GNU
+// Lesser General Public License Version 3 or the Perl Artistic License
+// Version 2.0.
+// SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+
+// using public_on causes one to be AstCellInline, and that one has correct scope
+// without this, both are AstCellInline, and both are wrong
+
+/* verilator public_on */
+
+module t (  /*AUTOARG*/
+    x,
+    clk,
+    a
+);
+   input clk;
+   input [7:0] a;
+   output reg [7:0] x;
+
+
+   initial begin
+      $write("*-* All Finished *-*\n");
+      $finish();
+   end
+
+
+   gen_wrapper top_wrap_1 ();
+   gen_wrapper top_wrap_2 ();
+
+endmodule : t
+
+module sub;
+   reg subsig1;
+endmodule : sub
+
+
+module gen_wrapper #(
+   parameter int LENGTH = 1
+);
+   genvar i;
+   generate
+      for (i = 0; i < LENGTH; i++) begin : gen_loop
+
+         // This fixes the scope
+         // localparam int x  = LENGTH;
+
+         sub after_gen_loop ();
+      end
+   endgenerate
+endmodule


### PR DESCRIPTION
This one seems to a bit trickier than the last missing scope. I put some comments in the code about how slight modifications change the tree. Here's the part of the final tree for this version. Notice that there's only one gen_loop__BRA__0__KET__  CellInline, and not one for t.top_wrap_1. However if I take out the public_on (so it's public_flat now), it get's both as CellInline, but misses the correct scope on both

```
    1:2: CUSE 0x55bb83d952c0 {e31aq}  gen_wrapper [INT_FWD]
    1: MODULE 0x55bb83d6db00 {e41ai}  gen_wrapper  L3 [P] [1ps]
    1:1: CELLINLINE 0x55bb83dcf2c0 {e46ah}  gen_loop -> __BEGIN__ [scopep=0x55bb83d771e0]
    1:1: CELLINLINE 0x55bb83dcf1d0 {e51ao}  gen_loop__BRA__0__KET__ -> __BEGIN__ [scopep=0x55bb83d771e0]
    1:2: VAR 0x55bb83e4e160 {e42as} @dt=0x55bb83dd1e00@(G/sw32)  LENGTH [P] [VSTATIC]  GPARAM
    1:2:3: CONST 0x55bb83d775f0 {e42bb} @dt=0x55bb83e500c0@(G/sw32)  32'sh1
    1:2: CELL 0x55bb83d6cc60 {e51ao}  gen_loop__BRA__0__KET____DOT__after_gen_loop -> MODULE 0x55bb83d6d9e0 {e36ai}  sub  L4 [P] [1ps]
    1:2: SCOPE 0x55bb83d77040 {e31aq}  TOP.t.top_wrap_1 [abovep=0x55bb83d76f70] [cellp=0x55bb83d6d7a0] [modp=0x55bb83d6db00]
    1:2: SCOPE 0x55bb83d771e0 {e32aq}  TOP.t.top_wrap_2 [abovep=0x55bb83d76f70] [cellp=0x55bb83d6d8c0] [modp=0x55bb83d6db00]
    1:2: CFUNC 0x55bb83e7b8c0 {e41ai}  _ctor_var_reset [SLOW]
    1:2: CUSE 0x55bb83d955c0 {e51ao}  sub [INT_FWD]
    1: MODULE 0x55bb83d6d9e0 {e36ai}  sub  L4 [P] [1ps]
```